### PR TITLE
Disable WordPress Core REST API endpoints for logged-out users

### DIFF
--- a/fx-private-site.php
+++ b/fx-private-site.php
@@ -3,7 +3,7 @@
  * Plugin Name: f(x) Private Site
  * Plugin URI: http://genbumedia.com/plugins/fx-private-site/
  * Description: Set your site to member only. All visitor will need to login to view site.
- * Version: 1.2.0
+ * Version: 1.2.2
  * Author: David Chandra Purnama
  * Author URI: http://shellcreeper.com/
  * License: GPLv2 or later
@@ -18,7 +18,7 @@ if ( ! defined( 'WPINC' ) ) { die; }
 ------------------------------------------ */
 
 /* Set the version constant. */
-define( 'FX_PRIVATE_SITE_VERSION', '1.2.0' );
+define( 'FX_PRIVATE_SITE_VERSION', '1.2.2' );
 
 /* Set the constant path to the plugin path. */
 define( 'FX_PRIVATE_SITE_PATH', trailingslashit( plugin_dir_path( __FILE__ ) ) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -56,7 +56,7 @@ add_filter( 'comment_text_rss', 'fx_private_site_feed_content', 95 );
 
 add_filter( 'rest_endpoints', 'fx_rest_endpoints', 95 );
 function fx_rest_endpoints( $endpoints ) {
-	if ( is_user_logged_in() ) {
+	if ( ! fx_private_site_get_option( 'enable', false ) || is_user_logged_in() ) {
 		return $endpoints;
 	}
 
@@ -71,7 +71,7 @@ function fx_rest_endpoints( $endpoints ) {
 
 add_filter( 'rest_index', 'fx_rest_index', 95 );
 function fx_rest_index( $response ) {
-	if ( is_user_logged_in() ) {
+	if ( ! fx_private_site_get_option( 'enable', false ) || is_user_logged_in() ) {
 		return $response;
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -54,6 +54,32 @@ add_filter( 'the_content_feed', 'fx_private_site_feed_content', 95 );
 add_filter( 'the_excerpt_rss',  'fx_private_site_feed_content', 95 );
 add_filter( 'comment_text_rss', 'fx_private_site_feed_content', 95 );
 
+add_filter( 'rest_endpoints', 'fx_rest_endpoints', 95 );
+function fx_rest_endpoints( $endpoints ) {
+	if ( is_user_logged_in() ) {
+		return $endpoints;
+	}
+
+	foreach ( $endpoints as $route => $endpoint ){
+		if ( 0 === stripos( $route, '/wp/v2' ) ){
+			unset( $endpoints[ $route ] );
+		}
+	}
+
+	return $endpoints;
+}
+
+add_filter( 'rest_index', 'fx_rest_index', 95 );
+function fx_rest_index( $response ) {
+	if ( is_user_logged_in() ) {
+		return $response;
+	}
+
+	unset( $response->data['name'] );
+	unset( $response->data['description'] );
+
+	return $response;
+}
 
 /**
  * Redirects users that are not logged in to the 'wp-login.php' page.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: private site, members only, protect rss
 Requires at least: 4.0
 Tested up to: 4.6
-Stable tag: 1.2.0
+Stable tag: 1.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -45,6 +45,12 @@ The settings is in the bottom of "Settings > Reading" in your admin panel. You w
 1. Private Site Setting.
 
 == Changelog ==
+
+= 1.2.2 - 31 July 2017 =
+Disable REST API for logged-out users to prevent snooping.
+
+= 1.2.1 - 31 July 2017 =
+* Whitelist WordPress robots.txt credit to [Alex Kirk](https://alexander.kirk.at/)
 
 = 1.2.0 - 09 September 2016 =
 * Better whitelist for buddypress https://github.com/justintadlock/members/issues/83#issuecomment-245237479

--- a/readme.txt
+++ b/readme.txt
@@ -46,10 +46,10 @@ The settings is in the bottom of "Settings > Reading" in your admin panel. You w
 
 == Changelog ==
 
-= 1.2.2 - 31 July 2017 =
-Disable REST API for logged-out users to prevent snooping.
+= 1.2.2 - October 26, 2018 =
+Remove name and description from the REST response, ensure posts have a post_status private so that they don't appear in unauthenticated REST responses.
 
-= 1.2.1 - 31 July 2017 =
+= 1.2.1 - 31 July 2018 =
 * Whitelist WordPress robots.txt credit to [Alex Kirk](https://alexander.kirk.at/)
 
 = 1.2.0 - 09 September 2016 =


### PR DESCRIPTION
As of now, a private site can be accessed via the REST API via endpoints like `/wp/v2/posts`, since the posts all still have a `post_status === 'publish'` and the REST API is not aware that the site itself should be deemed private.

To solve this we can disable the built-in REST routes which can spill the beans.

This also removes site name and description from the `/wp-json/` overview endpoint.